### PR TITLE
Add gripper blocking option and enable default wait behavior

### DIFF
--- a/bigym/action_modes.py
+++ b/bigym/action_modes.py
@@ -189,6 +189,8 @@ class JointPositionActionMode(ActionMode):
         self,
         absolute: bool = False,
         block_until_reached: bool = False,
+        block_gripper_until_reached: bool = True,
+        gripper_tolerance: float = 0.05,
         floating_base: bool = True,
         floating_dofs: list[PelvisDof] = None,
     ):
@@ -197,6 +199,10 @@ class JointPositionActionMode(ActionMode):
         :param absolute: Use absolute or delta joint positions.
         :param block_until_reached: Continue stepping until the target
             position is reached or the step threshold is exceeded.
+        :param block_gripper_until_reached: Continue stepping until gripper
+            target state is reached or the step threshold is exceeded.
+        :param gripper_tolerance: Allowed gripper absolute error in normalized
+            gripper range before considering the target reached.
         """
         super().__init__(
             floating_base=floating_base,
@@ -204,6 +210,8 @@ class JointPositionActionMode(ActionMode):
         )
         self.absolute = absolute
         self.block_until_reached = block_until_reached
+        self.block_gripper_until_reached = block_gripper_until_reached
+        self.gripper_tolerance = gripper_tolerance
 
     def action_space(
         self, action_scale: float, seed: Optional[int] = None
@@ -244,7 +252,7 @@ class JointPositionActionMode(ActionMode):
         for side, action in zip(self._robot.grippers, gripper_actions):
             self._robot.grippers[side].set_control(action)
 
-        if self.block_until_reached:
+        if self.block_until_reached or self.block_gripper_until_reached:
             self._step_until_reached()
         else:
             self._mojo.step()
@@ -294,10 +302,15 @@ class JointPositionActionMode(ActionMode):
                 break
 
     def _is_target_state_reached(self):
-        if self.floating_base:
-            if not self._robot.floating_base.is_target_reached:
-                return False
-        for actuator in self._robot.limb_actuators:
-            if not is_target_reached(actuator, self._mojo.physics, TOLERANCE_ANGULAR):
-                return False
+        if self.block_until_reached:
+            if self.floating_base:
+                if not self._robot.floating_base.is_target_reached:
+                    return False
+            for actuator in self._robot.limb_actuators:
+                if not is_target_reached(actuator, self._mojo.physics, TOLERANCE_ANGULAR):
+                    return False
+        if self.block_gripper_until_reached:
+            for _, gripper in self._robot.grippers.items():
+                if not gripper.is_target_reached(self.gripper_tolerance):
+                    return False
         return True

--- a/bigym/robots/gripper.py
+++ b/bigym/robots/gripper.py
@@ -38,6 +38,7 @@ class Gripper:
         self._actuators: list[mjcf.Element] = []
         self._actuated_joints: list[mjcf.Element] = []
         self._pinch_site: Optional[Site] = None
+        self._target_ctrl: Optional[float] = None
 
         if self._config.model:
             self._body: Body = self._mojo.load_model(
@@ -115,10 +116,17 @@ class Gripper:
         if self._config.discrete:
             ctrl = np.round(ctrl)
         ctrl = np.interp(ctrl, self._NORMAL_RANGE, self._config.range)
+        self._target_ctrl = float(ctrl)
         for actuator in self._actuators:
             actuator = self._mojo.physics.bind(actuator)
-            ctrl = np.interp(ctrl, self._config.range, actuator.ctrlrange)
-            actuator.ctrl = ctrl
+            actuator_ctrl = np.interp(ctrl, self._config.range, actuator.ctrlrange)
+            actuator.ctrl = actuator_ctrl
+
+    def is_target_reached(self, tolerance: float) -> bool:
+        """Check if the gripper is sufficiently close to the last control target."""
+        if self._target_ctrl is None:
+            return True
+        return abs(self.qpos - self._target_ctrl) <= tolerance
 
     def _on_loaded(self, model: mjcf.RootElement):
         model.model += f"_{self._side.value.lower()}"


### PR DESCRIPTION
### What changed
  - `bigym/action_modes.py`
    - Added `block_gripper_until_reached: bool` (default `True`)
    - Added `gripper_tolerance: float` (default `0.05`)
    - `step()` now enters internal stepping loop when either:
      - `block_until_reached=True`, or
      - `block_gripper_until_reached=True`
    - `_is_target_state_reached()` now optionally checks gripper convergence.

  - `bigym/robots/gripper.py`
    - Added target tracking for the last commanded gripper control.
    - Added `is_target_reached(tolerance)` to determine whether gripper position is close enough to
  target.

  ## Why
  This makes gripper behavior closer to “command is discrete, motion is physical and progressive, API
  returns after convergence”, which improves consistency for demo replay/rendering pipelines that assume
  post-action gripper state.

  ## Behavior impact
  - `JointPositionActionMode` default behavior changes:
    - Gripper wait is now ON by default.
  - This may increase per-step runtime in environments/scripts that do not override the new option.